### PR TITLE
fix(controls): FullScreen on `ESC` key is now working

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # `video.ts`
 
-This is a simple video-player completely written in `typescript` and this is an inspiration from both
-the epic video-players **NETFLIX** & **YOUTUBE**, I call it a mixture.
+This is a simple video-player completely written in `typescript` and this is an
+inspiration from both the epic video-players **NETFLIX** & **YOUTUBE**,
+I call it a mixture.
+
+For now, this is a simple video player template written in `typescript`, which
+is only supported in desktop mode. This is still considered under-developed,
+But will be soon released as a fully-functioning, well-working video player,
+supporting rich features like streaming and HLS, along with prominent video
+settings.
 
 > **Note**: Please place your video file inside the `public/videos/` folder &
-> then reference the video at `/src/components/VideoPlayer/index.tsx:222` (line 222)
+> then reference the video at `/src/components/VideoPlayer/index.tsx:222`
+> (line 222)
 
 ## TODO
 

--- a/src/components/Controls/index.tsx
+++ b/src/components/Controls/index.tsx
@@ -105,14 +105,10 @@ const Controls = ({
     const container = contRef.current;
     console.log("expand/collapse ran");
     if (container) {
-      if (isFullScreen) {
-        console.log(document);
-        document.exitFullscreen().then(() => setIsFullScreen(false));
-        console.log("Full Screen exiting");
-      } else {
-        container.requestFullscreen().then(() => setIsFullScreen(true));
-        console.log("Full Screen entering");
-      }
+      if (document.fullscreenElement)
+        document.exitFullscreen();
+      else
+        container.requestFullscreen();
     }
   };
 


### PR DESCRIPTION
The `ESC` key error when in fullscreen mode for the video is now fixed and is working properly. Now fullscreen mode is easily toggling without any issue.